### PR TITLE
fix: adicionando testes para a exceção do N1

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/util/InicializationExceptionHandlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/InicializationExceptionHandlerTest.java
@@ -1,0 +1,30 @@
+package org.jabref.logic.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InicializationExceptionHandlerTest {
+
+    @Test
+    void testConstructorWithMessageAndCause() {
+        Throwable cause = new RuntimeException("root");
+        String message = "Something failed";
+
+        InicializationExceptionHandler ex =
+                new InicializationExceptionHandler(message, cause);
+
+        assertEquals(message, ex.getMessage());
+        assertEquals(cause, ex.getCause());
+    }
+
+    @Test
+    void testConstructorWithOnlyCauseUsesDefaultMessage() {
+        Throwable cause = new RuntimeException("root");
+
+        InicializationExceptionHandler ex =
+                new InicializationExceptionHandler(cause);
+
+        assertEquals("Failed to initialize JabRef modules", ex.getMessage());
+        assertEquals(cause, ex.getCause());
+    }
+}


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... Summarize changes and DO NOT list modified classes one-by-one. (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
